### PR TITLE
Add disclaimer for pre-Apache releases.

### DIFF
--- a/_layouts/release.html
+++ b/_layouts/release.html
@@ -3,6 +3,13 @@ layout: default
 permalink: /release/release-notes-:title
 ---
 
+<div class="legacy-release-note">
+    <p><strong>The release below is from prior to Guacamole's acceptance into
+        the Apache Incubator.</strong> It is not an Apache Software Foundation
+        release, and is licensed under the <a
+    href="https://opensource.org/licenses/MIT">MIT license</a>.</p>
+</div>
+
 <div id="links">
 
     <!-- Compatible extensions -->

--- a/releases.md
+++ b/releases.md
@@ -19,6 +19,14 @@ Which version should I download?
 
 Unless you already know that you need a *very* specific version (your custom or third-party extensions use an older version of the Guacamole API, for example), **you should always download the most recent release**. Guacamole development is very active, and recent releases will contain bug fixes and performance improvements that will be absent in older releases.
 
+<div class="legacy-release-note">
+    <p>The Apache Guacamole project has not yet made a release through the
+    Apache Incubator. <strong>All releases below are from prior to Guacamole's
+    acceptance into the Incubator.</strong> They are not Apache Software
+    Foundation releases, and are licensed under the <a
+    href="https://opensource.org/licenses/MIT">MIT license</a>.</p>
+</div>
+
 <table class="releases">
     <tr>
         <th>Version</th>

--- a/styles/main.css
+++ b/styles/main.css
@@ -451,7 +451,7 @@ table.releases {
     border: 1px solid rgba(0, 0, 0, 0.5);
     margin-left: auto;
     margin-right: auto;
-    margin-top: 4em;
+    margin-top: 0.25in;
     margin-bottom: 4em;
 }
 
@@ -478,6 +478,13 @@ table.releases td {
     padding-bottom: 0.5em;
     padding-left: 1em;
     padding-right: 1em;
+}
+
+#content > .legacy-release-note {
+    background: #FFFFFA;
+    border: 1px solid rgba(0, 0, 0, 0.25);
+    width: 8in;
+    margin: 0.25in auto;
 }
 
 /* Style appropriately for printing */


### PR DESCRIPTION
This change adds a disclaimer to the release archive and release notes describing the origin and non-Apache nature of past releases. From the ["Hosting links to pre-Apache releases"](https://mail-archives.apache.org/mod_mbox/incubator-general/201603.mbox/%3C56E7421B.6030808@shanecurcuru.org%3E) thread on the Apache Incubator general mailing list, regarding whether projects may host links to past releases:

> Sounds appropriate to me.  Ensure people know they're not ASF releases, but are from the earlier organization (i.e. whoever is donating the project), and be crystal clear if the license is different than the Apache license.
