### PR TITLE
Include site title in all pages.

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,5 +3,5 @@
     <link rel="icon" type="image/png" href="/images/guacamole-logo-64.png"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densitydpi=device-dpi"/>
     <meta charset="UTF-8"/>
-    <title>{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
+    <title>{{ site.title | escape }}{% if page.title %}: {{ page.title | escape }}{% endif %}</title>
 </head>


### PR DESCRIPTION
Prior to this, pages like the 0.9.9 release notes would render with the title of simply "0.9.9". Now, they render as "Apache Guacamole: 0.9.9".