### PR TITLE
Ensure "incubating" is clearly stated in the title.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@
 #
 
 # Site settings
-title: Apache Guacamole
+title: Apache Guacamole (incubating)
 
 # Build settings
 markdown: kramdown

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,6 +1,6 @@
 <!-- Header -->
 <div id="header">
-    <h1><a href="/">Apache Guacamole</a></h1>
+    <h1><a href="/">{{ site.title }}</a></h1>
     <ul id="navigation" class="menu">
         {% assign menu_pages = site.pages %}
         {% for link in site.links %}


### PR DESCRIPTION
There has been a recent uptick in traffic due to a post to Hacker News (https://news.ycombinator.com/item?id=11744430). From posts in the comment thread, it is becoming clear that Guacamole's incubating status needs to be **MUCH** more clearly stated.

This change adds "(incubating)" to the title, where it really should already have been.