### PR TITLE
Allow normal wrapping for small screens

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -602,6 +602,7 @@ table.releases td {
 
     #header h1 {
         font-size: 1.75em;
+        white-space: normal;
     }
 
     div#header > * {


### PR DESCRIPTION
Without these changes, the word "incubating" overflows smaller screens.