### PR TITLE
Exclude add-tracking.pl from deploy.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,7 @@ title: Apache Guacamole (incubating)
 markdown: kramdown
 exclude:
     - README.md
+    - add-tracking.pl
     - build.sh
     - content
     - doc


### PR DESCRIPTION
Just like `build.sh`, the new `add-tracking.pl` utility script should not be included in the deployed website content.