### PR TITLE
Move release artifacts into "source/" and "binary/" subdirectories.

### DIFF
--- a/_includes/download-list.html
+++ b/_includes/download-list.html
@@ -4,7 +4,7 @@
             <tr>
                 {% assign mirror = include.artifact-root | append: include.path %}
                 {% assign dist = include.checksum-root | append: include.path %}
-                <td><a href="{{ mirror | append: file }}">{{ file }}</a></td>
+                <td><a href="{{ mirror | append: file }}">{{ file | split: "/" | last }}</a></td>
                 <td>[ <a href="{{ dist | append: file }}.md5">MD5</a> ]</td>
                 <td>[ <a href="{{ dist | append: file }}.sha">SHA</a> ]</td>
                 <td>[ <a href="{{ dist | append: file }}.asc">PGP</a> ]</td>

--- a/_releases/0.9.10-incubating.md
+++ b/_releases/0.9.10-incubating.md
@@ -12,14 +12,14 @@ checksum-root: "https://dist.apache.org/repos/dist/dev/"
 download-path: "incubator/guacamole/0.9.10-incubating-RC2/"
 
 source-dist:
-    - "guacamole-client-0.9.10-incubating.tar.gz"
-    - "guacamole-server-0.9.10-incubating.tar.gz"
+    - "source/guacamole-client-0.9.10-incubating.tar.gz"
+    - "source/guacamole-server-0.9.10-incubating.tar.gz"
 
 binary-dist:
-    - "guacamole-0.9.10-incubating.war"
-    - "guacamole-auth-jdbc-0.9.10-incubating.tar.gz"
-    - "guacamole-auth-ldap-0.9.10-incubating.tar.gz"
-    - "guacamole-auth-noauth-0.9.10-incubating.tar.gz"
+    - "binary/guacamole-0.9.10-incubating.war"
+    - "binary/guacamole-auth-jdbc-0.9.10-incubating.tar.gz"
+    - "binary/guacamole-auth-ldap-0.9.10-incubating.tar.gz"
+    - "binary/guacamole-auth-noauth-0.9.10-incubating.tar.gz"
 
 documentation:
     "Manual"              : "/doc/0.9.10-incubating/gug"


### PR DESCRIPTION
Per recent discussion on the IPMC vote for the 0.9.10-incubating release, this change links to artifacts organized into "source/" and "binary/" subdirectories.