### PR TITLE
Track download statistics using Google Analytics

### DIFF
--- a/_includes/download-list.html
+++ b/_includes/download-list.html
@@ -4,13 +4,14 @@
             <tr>
                 {% assign mirror = include.artifact-root | append: include.path %}
                 {% assign dist = include.checksum-root | append: include.path %}
+                {% assign basename = file | split: "/" | last %}
                 <td><a href="{{ mirror | append: file }}"
                        onclick="ga('send', 'event', {
                            eventCategory : 'Download',
                            eventAction   : 'click',
-                           eventLabel    : '{{ file }}',
+                           eventLabel    : '{{ basename }}',
                            transport     : 'beacon'
-                       })">{{ file | split: "/" | last }}</a></td>
+                       })">{{ basename }}</a></td>
                 <td>[ <a href="{{ dist | append: file }}.md5">MD5</a> ]</td>
                 <td>[ <a href="{{ dist | append: file }}.sha">SHA</a> ]</td>
                 <td>[ <a href="{{ dist | append: file }}.asc">PGP</a> ]</td>

--- a/_includes/download-list.html
+++ b/_includes/download-list.html
@@ -4,7 +4,13 @@
             <tr>
                 {% assign mirror = include.artifact-root | append: include.path %}
                 {% assign dist = include.checksum-root | append: include.path %}
-                <td><a href="{{ mirror | append: file }}">{{ file | split: "/" | last }}</a></td>
+                <td><a href="{{ mirror | append: file }}"
+                       onclick="ga('send', 'event', {
+                           eventCategory : 'Download',
+                           eventAction   : 'click',
+                           eventLabel    : '{{ file }}',
+                           transport     : 'beacon'
+                       })">{{ file | split: "/" | last }}</a></td>
                 <td>[ <a href="{{ dist | append: file }}.md5">MD5</a> ]</td>
                 <td>[ <a href="{{ dist | append: file }}.sha">SHA</a> ]</td>
                 <td>[ <a href="{{ dist | append: file }}.asc">PGP</a> ]</td>

--- a/_includes/legacy-download-list.html
+++ b/_includes/legacy-download-list.html
@@ -1,0 +1,16 @@
+{% if include.entries != empty %}
+    {% if include.title %}
+        <h2>{{ include.title }}</h2>
+    {% endif %}
+    <ul>
+        {% for entry in include.entries %}
+            <li><a href="{{ entry[1] | prepend: site.baseurl }}"
+                   onclick="ga('send', 'event', {
+                       eventCategory : 'Download',
+                       eventAction   : 'click',
+                       eventLabel    : '{{ entry[0] }}',
+                       transport     : 'beacon'
+                   })">{{ entry[0] }}</a></li>
+        {% endfor %}
+    </ul>
+{% endif %}

--- a/_includes/legacy-download-list.html
+++ b/_includes/legacy-download-list.html
@@ -8,7 +8,7 @@
                    onclick="ga('send', 'event', {
                        eventCategory : 'Download',
                        eventAction   : 'click',
-                       eventLabel    : '{{ entry[0] }}',
+                       eventLabel    : '{{ entry[1] | split: "/" | last }}',
                        transport     : 'beacon'
                    })">{{ entry[0] }}</a></li>
         {% endfor %}

--- a/_layouts/legacy-release.html
+++ b/_layouts/legacy-release.html
@@ -13,17 +13,17 @@ permalink: /release/release-notes-:title
 <div id="links">
 
     <!-- Compatible extensions -->
-    {% include link-list.html
+    {% include legacy-download-list.html
         title="Compatible extensions"
         entries=page.extensions %}
 
     <!-- Binary .war -->
-    {% include link-list.html
+    {% include legacy-download-list.html
         title="Web application (.war)"
         entries=page.binary-war %}
 
     <!-- Source archives -->
-    {% include link-list.html
+    {% include legacy-download-list.html
         title="Source"
         entries=page.source-archives %}
 

--- a/_legacy-releases/0.8.3.md
+++ b/_legacy-releases/0.8.3.md
@@ -6,16 +6,16 @@ summary: >
     support.
 
 binary-war:
-    "guacamole-0.8.3.war" : "http://sourceforge.net/projects/guacamole/files/current/binary/guacamole-0.8.3.war/download"
+    "guacamole-0.8.3.war" : "http://downloads.sourceforge.net/project/guacamole/current/binary/guacamole-0.8.3.war"
 
 extensions:
-    "LDAP Authentication"              : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-ldap-0.8.0.tar.gz/download"
-    "MySQL Authentication"          : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-mysql-0.8.2.tar.gz/download"
-    "NoAuth (Disabled) Authentication" : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-noauth-0.8.0.tar.gz/download"
+    "LDAP Authentication"              : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-ldap-0.8.0.tar.gz"
+    "MySQL Authentication"          : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-mysql-0.8.2.tar.gz"
+    "NoAuth (Disabled) Authentication" : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-noauth-0.8.0.tar.gz"
 
 source-archives:
-    "guacamole-client-0.8.3.tar.gz" : "http://sourceforge.net/projects/guacamole/files/current/source/guacamole-client-0.8.3.tar.gz/download"
-    "guacamole-server-0.8.3.tar.gz" : "http://sourceforge.net/projects/guacamole/files/current/source/guacamole-server-0.8.3.tar.gz/download"
+    "guacamole-client-0.8.3.tar.gz" : "http://downloads.sourceforge.net/project/guacamole/current/source/guacamole-client-0.8.3.tar.gz"
+    "guacamole-server-0.8.3.tar.gz" : "http://downloads.sourceforge.net/project/guacamole/current/source/guacamole-server-0.8.3.tar.gz"
 
 documentation:
     "Manual"              : "/doc/0.8.3/gug"

--- a/_legacy-releases/0.8.4.md
+++ b/_legacy-releases/0.8.4.md
@@ -5,16 +5,16 @@ summary: >
     MySQL auth fixes
 
 binary-war:
-    "guacamole-0.8.4.war" : "http://sourceforge.net/projects/guacamole/files/current/binary/guacamole-0.8.4.war/download"
+    "guacamole-0.8.4.war" : "http://downloads.sourceforge.net/project/guacamole/current/binary/guacamole-0.8.4.war"
 
 extensions:
-    "LDAP Authentication"              : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-ldap-0.8.0.tar.gz/download"
-    "MySQL Authentication"          : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-mysql-0.8.4.tar.gz/download"
-    "NoAuth (Disabled) Authentication" : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-noauth-0.8.0.tar.gz/download"
+    "LDAP Authentication"              : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-ldap-0.8.0.tar.gz"
+    "MySQL Authentication"          : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-mysql-0.8.4.tar.gz"
+    "NoAuth (Disabled) Authentication" : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-noauth-0.8.0.tar.gz"
 
 source-archives:
-    "guacamole-client-0.8.4.tar.gz" : "http://sourceforge.net/projects/guacamole/files/current/source/guacamole-client-0.8.4.tar.gz/download"
-    "guacamole-server-0.8.4.tar.gz" : "http://sourceforge.net/projects/guacamole/files/current/source/guacamole-server-0.8.4.tar.gz/download"
+    "guacamole-client-0.8.4.tar.gz" : "http://downloads.sourceforge.net/project/guacamole/current/source/guacamole-client-0.8.4.tar.gz"
+    "guacamole-server-0.8.4.tar.gz" : "http://downloads.sourceforge.net/project/guacamole/current/source/guacamole-server-0.8.4.tar.gz"
 
 documentation:
     "Manual"              : "/doc/0.8.4/gug"

--- a/_legacy-releases/0.9.0.md
+++ b/_legacy-releases/0.9.0.md
@@ -6,16 +6,16 @@ summary: >
     error handling.
 
 binary-war:
-    "guacamole-0.9.0.war" : "http://sourceforge.net/projects/guacamole/files/current/binary/guacamole-0.9.0.war/download"
+    "guacamole-0.9.0.war" : "http://downloads.sourceforge.net/project/guacamole/current/binary/guacamole-0.9.0.war"
 
 extensions:
-    "LDAP Authentication"              : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-ldap-0.9.0.tar.gz/download"
-    "MySQL Authentication"          : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-mysql-0.9.0.tar.gz/download"
-    "NoAuth (Disabled) Authentication" : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-noauth-0.9.0.tar.gz/download"
+    "LDAP Authentication"              : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-ldap-0.9.0.tar.gz"
+    "MySQL Authentication"          : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-mysql-0.9.0.tar.gz"
+    "NoAuth (Disabled) Authentication" : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-noauth-0.9.0.tar.gz"
 
 source-archives:
-    "guacamole-client-0.9.0.tar.gz" : "http://sourceforge.net/projects/guacamole/files/current/source/guacamole-client-0.9.0.tar.gz/download"
-    "guacamole-server-0.9.0.tar.gz" : "http://sourceforge.net/projects/guacamole/files/current/source/guacamole-server-0.9.0.tar.gz/download"
+    "guacamole-client-0.9.0.tar.gz" : "http://downloads.sourceforge.net/project/guacamole/current/source/guacamole-client-0.9.0.tar.gz"
+    "guacamole-server-0.9.0.tar.gz" : "http://downloads.sourceforge.net/project/guacamole/current/source/guacamole-server-0.9.0.tar.gz"
 
 documentation:
     "Manual"              : "/doc/0.9.0/gug"

--- a/_legacy-releases/0.9.1.md
+++ b/_legacy-releases/0.9.1.md
@@ -6,16 +6,16 @@ summary: >
     auth fixes
 
 binary-war:
-    "guacamole-0.9.1.war" : "http://sourceforge.net/projects/guacamole/files/current/binary/guacamole-0.9.1.war/download"
+    "guacamole-0.9.1.war" : "http://downloads.sourceforge.net/project/guacamole/current/binary/guacamole-0.9.1.war"
 
 extensions:
-    "LDAP Authentication"              : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-ldap-0.9.0.tar.gz/download"
-    "MySQL Authentication"          : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-mysql-0.9.1.tar.gz/download"
-    "NoAuth (Disabled) Authentication" : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-noauth-0.9.0.tar.gz/download"
+    "LDAP Authentication"              : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-ldap-0.9.0.tar.gz"
+    "MySQL Authentication"          : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-mysql-0.9.1.tar.gz"
+    "NoAuth (Disabled) Authentication" : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-noauth-0.9.0.tar.gz"
 
 source-archives:
-    "guacamole-client-0.9.1.tar.gz" : "http://sourceforge.net/projects/guacamole/files/current/source/guacamole-client-0.9.1.tar.gz/download"
-    "guacamole-server-0.9.1.tar.gz" : "http://sourceforge.net/projects/guacamole/files/current/source/guacamole-server-0.9.1.tar.gz/download"
+    "guacamole-client-0.9.1.tar.gz" : "http://downloads.sourceforge.net/project/guacamole/current/source/guacamole-client-0.9.1.tar.gz"
+    "guacamole-server-0.9.1.tar.gz" : "http://downloads.sourceforge.net/project/guacamole/current/source/guacamole-server-0.9.1.tar.gz"
 
 documentation:
     "Manual"              : "/doc/0.9.1/gug"

--- a/_legacy-releases/0.9.2.md
+++ b/_legacy-releases/0.9.2.md
@@ -6,16 +6,16 @@ summary: >
     bug fixes.
 
 binary-war:
-    "guacamole-0.9.2.war" : "http://sourceforge.net/projects/guacamole/files/current/binary/guacamole-0.9.2.war/download"
+    "guacamole-0.9.2.war" : "http://downloads.sourceforge.net/project/guacamole/current/binary/guacamole-0.9.2.war"
 
 extensions:
-    "LDAP Authentication"              : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-ldap-0.9.2.tar.gz/download"
-    "MySQL Authentication"          : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-mysql-0.9.2.tar.gz/download"
-    "NoAuth (Disabled) Authentication" : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-noauth-0.9.2.tar.gz/download"
+    "LDAP Authentication"              : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-ldap-0.9.2.tar.gz"
+    "MySQL Authentication"          : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-mysql-0.9.2.tar.gz"
+    "NoAuth (Disabled) Authentication" : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-noauth-0.9.2.tar.gz"
 
 source-archives:
-    "guacamole-client-0.9.2.tar.gz" : "http://sourceforge.net/projects/guacamole/files/current/source/guacamole-client-0.9.2.tar.gz/download"
-    "guacamole-server-0.9.2.tar.gz" : "http://sourceforge.net/projects/guacamole/files/current/source/guacamole-server-0.9.2.tar.gz/download"
+    "guacamole-client-0.9.2.tar.gz" : "http://downloads.sourceforge.net/project/guacamole/current/source/guacamole-client-0.9.2.tar.gz"
+    "guacamole-server-0.9.2.tar.gz" : "http://downloads.sourceforge.net/project/guacamole/current/source/guacamole-server-0.9.2.tar.gz"
 
 documentation:
     "Manual"              : "/doc/0.9.2/gug"

--- a/_legacy-releases/0.9.3.md
+++ b/_legacy-releases/0.9.3.md
@@ -6,16 +6,16 @@ summary: >
     codes, bug fixes.
 
 binary-war:
-    "guacamole-0.9.3.war" : "http://sourceforge.net/projects/guacamole/files/current/binary/guacamole-0.9.3.war/download"
+    "guacamole-0.9.3.war" : "http://downloads.sourceforge.net/project/guacamole/current/binary/guacamole-0.9.3.war"
 
 extensions:
-    "LDAP Authentication"              : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-ldap-0.9.3.tar.gz/download"
-    "MySQL Authentication"          : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-mysql-0.9.3.tar.gz/download"
-    "NoAuth (Disabled) Authentication" : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-noauth-0.9.3.tar.gz/download"
+    "LDAP Authentication"              : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-ldap-0.9.3.tar.gz"
+    "MySQL Authentication"          : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-mysql-0.9.3.tar.gz"
+    "NoAuth (Disabled) Authentication" : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-noauth-0.9.3.tar.gz"
 
 source-archives:
-    "guacamole-client-0.9.3.tar.gz" : "http://sourceforge.net/projects/guacamole/files/current/source/guacamole-client-0.9.3.tar.gz/download"
-    "guacamole-server-0.9.3.tar.gz" : "http://sourceforge.net/projects/guacamole/files/current/source/guacamole-server-0.9.3.tar.gz/download"
+    "guacamole-client-0.9.3.tar.gz" : "http://downloads.sourceforge.net/project/guacamole/current/source/guacamole-client-0.9.3.tar.gz"
+    "guacamole-server-0.9.3.tar.gz" : "http://downloads.sourceforge.net/project/guacamole/current/source/guacamole-server-0.9.3.tar.gz"
 
 documentation:
     "Manual"              : "/doc/0.9.3/gug"

--- a/_legacy-releases/0.9.4.md
+++ b/_legacy-releases/0.9.4.md
@@ -6,16 +6,16 @@ summary: >
     simultaneous connections.
 
 binary-war:
-    "guacamole-0.9.4.war" : "http://sourceforge.net/projects/guacamole/files/current/binary/guacamole-0.9.4.war/download"
+    "guacamole-0.9.4.war" : "http://downloads.sourceforge.net/project/guacamole/current/binary/guacamole-0.9.4.war"
 
 extensions:
-    "LDAP Authentication"              : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-ldap-0.9.4.tar.gz/download"
-    "MySQL Authentication"          : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-mysql-0.9.4.tar.gz/download"
-    "NoAuth (Disabled) Authentication" : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-noauth-0.9.4.tar.gz/download"
+    "LDAP Authentication"              : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-ldap-0.9.4.tar.gz"
+    "MySQL Authentication"          : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-mysql-0.9.4.tar.gz"
+    "NoAuth (Disabled) Authentication" : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-noauth-0.9.4.tar.gz"
 
 source-archives:
-    "guacamole-client-0.9.4.tar.gz" : "http://sourceforge.net/projects/guacamole/files/current/source/guacamole-client-0.9.4.tar.gz/download"
-    "guacamole-server-0.9.4.tar.gz" : "http://sourceforge.net/projects/guacamole/files/current/source/guacamole-server-0.9.4.tar.gz/download"
+    "guacamole-client-0.9.4.tar.gz" : "http://downloads.sourceforge.net/project/guacamole/current/source/guacamole-client-0.9.4.tar.gz"
+    "guacamole-server-0.9.4.tar.gz" : "http://downloads.sourceforge.net/project/guacamole/current/source/guacamole-server-0.9.4.tar.gz"
 
 documentation:
     "Manual"              : "/doc/0.9.4/gug"

--- a/_legacy-releases/0.9.5.md
+++ b/_legacy-releases/0.9.5.md
@@ -6,16 +6,16 @@ summary: >
     SSH and telnet.
 
 binary-war:
-    "guacamole-0.9.5.war" : "http://sourceforge.net/projects/guacamole/files/current/binary/guacamole-0.9.5.war/download"
+    "guacamole-0.9.5.war" : "http://downloads.sourceforge.net/project/guacamole/current/binary/guacamole-0.9.5.war"
 
 extensions:
-    "LDAP Authentication"              : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-ldap-0.9.5.tar.gz/download"
-    "MySQL Authentication"          : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-mysql-0.9.5.tar.gz/download"
-    "NoAuth (Disabled) Authentication" : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-noauth-0.9.5.tar.gz/download"
+    "LDAP Authentication"              : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-ldap-0.9.5.tar.gz"
+    "MySQL Authentication"          : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-mysql-0.9.5.tar.gz"
+    "NoAuth (Disabled) Authentication" : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-noauth-0.9.5.tar.gz"
 
 source-archives:
-    "guacamole-client-0.9.5.tar.gz" : "http://sourceforge.net/projects/guacamole/files/current/source/guacamole-client-0.9.5.tar.gz/download"
-    "guacamole-server-0.9.5.tar.gz" : "http://sourceforge.net/projects/guacamole/files/current/source/guacamole-server-0.9.5.tar.gz/download"
+    "guacamole-client-0.9.5.tar.gz" : "http://downloads.sourceforge.net/project/guacamole/current/source/guacamole-client-0.9.5.tar.gz"
+    "guacamole-server-0.9.5.tar.gz" : "http://downloads.sourceforge.net/project/guacamole/current/source/guacamole-server-0.9.5.tar.gz"
 
 documentation:
     "Manual"              : "/doc/0.9.5/gug"

--- a/_legacy-releases/0.9.6.md
+++ b/_legacy-releases/0.9.6.md
@@ -6,16 +6,16 @@ summary: >
     management.
 
 binary-war:
-    "guacamole-0.9.6.war" : "http://sourceforge.net/projects/guacamole/files/current/binary/guacamole-0.9.6.war/download"
+    "guacamole-0.9.6.war" : "http://downloads.sourceforge.net/project/guacamole/current/binary/guacamole-0.9.6.war"
 
 extensions:
-    "Database Authentication"          : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-jdbc-0.9.6.tar.gz/download"
-    "LDAP Authentication"              : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-ldap-0.9.6.tar.gz/download"
-    "NoAuth (Disabled) Authentication" : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-noauth-0.9.6.tar.gz/download"
+    "Database Authentication"          : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-jdbc-0.9.6.tar.gz"
+    "LDAP Authentication"              : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-ldap-0.9.6.tar.gz"
+    "NoAuth (Disabled) Authentication" : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-noauth-0.9.6.tar.gz"
 
 source-archives:
-    "guacamole-client-0.9.6.tar.gz" : "http://sourceforge.net/projects/guacamole/files/current/source/guacamole-client-0.9.6.tar.gz/download"
-    "guacamole-server-0.9.6.tar.gz" : "http://sourceforge.net/projects/guacamole/files/current/source/guacamole-server-0.9.6.tar.gz/download"
+    "guacamole-client-0.9.6.tar.gz" : "http://downloads.sourceforge.net/project/guacamole/current/source/guacamole-client-0.9.6.tar.gz"
+    "guacamole-server-0.9.6.tar.gz" : "http://downloads.sourceforge.net/project/guacamole/current/source/guacamole-server-0.9.6.tar.gz"
 
 documentation:
     "Manual"              : "/doc/0.9.6/gug"

--- a/_legacy-releases/0.9.7.md
+++ b/_legacy-releases/0.9.7.md
@@ -6,16 +6,16 @@ summary: >
     translations, multiple bug fixes.
 
 binary-war:
-    "guacamole-0.9.7.war" : "http://sourceforge.net/projects/guacamole/files/current/binary/guacamole-0.9.7.war/download"
+    "guacamole-0.9.7.war" : "http://downloads.sourceforge.net/project/guacamole/current/binary/guacamole-0.9.7.war"
 
 extensions:
-    "Database Authentication"          : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-jdbc-0.9.7.tar.gz/download"
-    "LDAP Authentication"              : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-ldap-0.9.7.tar.gz/download"
-    "NoAuth (Disabled) Authentication" : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-noauth-0.9.7.tar.gz/download"
+    "Database Authentication"          : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-jdbc-0.9.7.tar.gz"
+    "LDAP Authentication"              : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-ldap-0.9.7.tar.gz"
+    "NoAuth (Disabled) Authentication" : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-noauth-0.9.7.tar.gz"
 
 source-archives:
-    "guacamole-client-0.9.7.tar.gz" : "http://sourceforge.net/projects/guacamole/files/current/source/guacamole-client-0.9.7.tar.gz/download"
-    "guacamole-server-0.9.7.tar.gz" : "http://sourceforge.net/projects/guacamole/files/current/source/guacamole-server-0.9.7.tar.gz/download"
+    "guacamole-client-0.9.7.tar.gz" : "http://downloads.sourceforge.net/project/guacamole/current/source/guacamole-client-0.9.7.tar.gz"
+    "guacamole-server-0.9.7.tar.gz" : "http://downloads.sourceforge.net/project/guacamole/current/source/guacamole-server-0.9.7.tar.gz"
 
 documentation:
     "Manual"              : "/doc/0.9.7/gug"

--- a/_legacy-releases/0.9.8.md
+++ b/_legacy-releases/0.9.8.md
@@ -6,16 +6,16 @@ summary: >
     performance flags.
 
 binary-war:
-    "guacamole-0.9.8.war" : "http://sourceforge.net/projects/guacamole/files/current/binary/guacamole-0.9.8.war/download"
+    "guacamole-0.9.8.war" : "http://downloads.sourceforge.net/project/guacamole/current/binary/guacamole-0.9.8.war"
 
 extensions:
-    "Database Authentication"          : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-jdbc-0.9.8.tar.gz/download"
-    "LDAP Authentication"              : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-ldap-0.9.8.tar.gz/download"
-    "NoAuth (Disabled) Authentication" : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-noauth-0.9.8.tar.gz/download"
+    "Database Authentication"          : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-jdbc-0.9.8.tar.gz"
+    "LDAP Authentication"              : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-ldap-0.9.8.tar.gz"
+    "NoAuth (Disabled) Authentication" : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-noauth-0.9.8.tar.gz"
 
 source-archives:
-    "guacamole-client-0.9.8.tar.gz" : "http://sourceforge.net/projects/guacamole/files/current/source/guacamole-client-0.9.8.tar.gz/download"
-    "guacamole-server-0.9.8.tar.gz" : "http://sourceforge.net/projects/guacamole/files/current/source/guacamole-server-0.9.8.tar.gz/download"
+    "guacamole-client-0.9.8.tar.gz" : "http://downloads.sourceforge.net/project/guacamole/current/source/guacamole-client-0.9.8.tar.gz"
+    "guacamole-server-0.9.8.tar.gz" : "http://downloads.sourceforge.net/project/guacamole/current/source/guacamole-server-0.9.8.tar.gz"
 
 documentation:
     "Manual"              : "/doc/0.9.8/gug"

--- a/_legacy-releases/0.9.9.md
+++ b/_legacy-releases/0.9.9.md
@@ -6,16 +6,16 @@ summary: >
     filterable connection/user lists.
 
 binary-war:
-    "guacamole-0.9.9.war" : "http://sourceforge.net/projects/guacamole/files/current/binary/guacamole-0.9.9.war/download"
+    "guacamole-0.9.9.war" : "http://downloads.sourceforge.net/project/guacamole/current/binary/guacamole-0.9.9.war"
 
 extensions:
-    "Database Authentication"          : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-jdbc-0.9.9.tar.gz/download"
-    "LDAP Authentication"              : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-ldap-0.9.9.tar.gz/download"
-    "NoAuth (Disabled) Authentication" : "http://sourceforge.net/projects/guacamole/files/current/extensions/guacamole-auth-noauth-0.9.9.tar.gz/download"
+    "Database Authentication"          : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-jdbc-0.9.9.tar.gz"
+    "LDAP Authentication"              : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-ldap-0.9.9.tar.gz"
+    "NoAuth (Disabled) Authentication" : "http://downloads.sourceforge.net/project/guacamole/current/extensions/guacamole-auth-noauth-0.9.9.tar.gz"
 
 source-archives:
-    "guacamole-client-0.9.9.tar.gz" : "http://sourceforge.net/projects/guacamole/files/current/source/guacamole-client-0.9.9.tar.gz/download"
-    "guacamole-server-0.9.9.tar.gz" : "http://sourceforge.net/projects/guacamole/files/current/source/guacamole-server-0.9.9.tar.gz/download"
+    "guacamole-client-0.9.9.tar.gz" : "http://downloads.sourceforge.net/project/guacamole/current/source/guacamole-client-0.9.9.tar.gz"
+    "guacamole-server-0.9.9.tar.gz" : "http://downloads.sourceforge.net/project/guacamole/current/source/guacamole-server-0.9.9.tar.gz"
 
 documentation:
     "Manual"              : "/doc/0.9.9/gug"


### PR DESCRIPTION
We currently use Google Analytics to track visits to the Apache Guacamole website, but downloads are not tracked. From the [ASF Release Policy](http://www.apache.org/dev/release.html#downloads):

>
> ## IS THERE ANY WAY TO MEASURE HOW MANY TIMES XYZ HAS BEEN DOWNLOADED?
>
> Not directly. Files are downloaded from the mirrors. Apache does not require mirrors to collect statistics about downloads.
>
> Counting the hits on the [download script](http://www.apache.org/dev/release-download-pages.html) should give a reasonable estimate. Various similar statistics are collected by [Vadim Gritsenko](http://home.apache.org/~vgritsenko/).
>

If we want to know how many times Guacamole is downloaded going forward, we need to do this tracking ourselves.

These changes add the necessary tracking such that an event is reported whenever a download link is clicked. So that the filenames of legacy downloads are correctly determined, I've also rearranged the download URLs for those releases. This has the happy secondary effect that downloads of old releases are now correctly handled via wget.