### PR TITLE
Consider opening the context menu on a download link to be a download.

### DIFF
--- a/_includes/download-list.html
+++ b/_includes/download-list.html
@@ -6,12 +6,14 @@
                 {% assign dist = include.checksum-root | append: include.path %}
                 {% assign basename = file | split: "/" | last %}
                 <td><a href="{{ mirror | append: file }}"
-                       onclick="ga('send', 'event', {
-                           eventCategory : 'Download',
-                           eventAction   : 'click',
-                           eventLabel    : '{{ basename }}',
-                           transport     : 'beacon'
-                       })">{{ basename }}</a></td>
+                       onclick="trackDownload(
+                           'click',
+                           '{{ basename }}'
+                       )"
+                       oncontextmenu="trackDownload(
+                           'menu',
+                           '{{ basename }}'
+                       )">{{ basename }}</a></td>
                 <td>[ <a href="{{ dist | append: file }}.md5">MD5</a> ]</td>
                 <td>[ <a href="{{ dist | append: file }}.sha">SHA</a> ]</td>
                 <td>[ <a href="{{ dist | append: file }}.asc">PGP</a> ]</td>

--- a/_includes/legacy-download-list.html
+++ b/_includes/legacy-download-list.html
@@ -5,12 +5,14 @@
     <ul>
         {% for entry in include.entries %}
             <li><a href="{{ entry[1] | prepend: site.baseurl }}"
-                   onclick="ga('send', 'event', {
-                       eventCategory : 'Download',
-                       eventAction   : 'click',
-                       eventLabel    : '{{ entry[1] | split: "/" | last }}',
-                       transport     : 'beacon'
-                   })">{{ entry[0] }}</a></li>
+                   onclick="trackDownload(
+                       'click',
+                       '{{ entry[1] | split: "/" | last }}'
+                   )"
+                   oncontextmenu="trackDownload(
+                       'menu',
+                       '{{ entry[1] | split: "/" | last }}'
+                   )">{{ entry[0] }}</a></li>
         {% endfor %}
     </ul>
 {% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,5 +27,32 @@
           ga('send', 'pageview');
         </script>
 
+        <!-- Download tracking helper function -->
+        <script type="text/javascript">
+
+            /**
+             * Signals Google Analytics that a file is being downloaded (or, at
+             * least, we expect that it is). Note that it is not possible to
+             * determine this with 100% certainty without grepping server logs,
+             * but this should still at least help gauge interest/usage.
+             *
+             * @param {String} action
+             *     A human-readable string describing the user event which
+             *     occurred to initiate the download.
+             *
+             * @param {String} filename
+             *     The filename of the file being downloaded.
+             */
+            function trackDownload(action, filename) {
+                ga('send', 'event', {
+                    eventCategory : 'Download',
+                    eventAction   : action,
+                    eventLabel    : filename,
+                    transport     : 'beacon'
+                });
+            }
+
+        </script>
+
     </body>
 </html>


### PR DESCRIPTION
The download statistics still don't match those of SourceForge. They're off by roughly an order of magnitude. My theory is that this may be due to the fact that the majority of downloads will *not* be occurring on the same machine as the browser, but rather remotely on the server where things will actually be installed.

We naturally can't see that information without access to the server logs, but perhaps we can track when the download URL is copied. This change does exactly that, considering the opening of the context menu on a download link to be a download.

If this fills the gap between our statistics and those of SourceForge, it should be almost immediately apparent.