### PR TITLE
Release 0.9.10-incubating

### DIFF
--- a/_releases/0.9.10-incubating.md
+++ b/_releases/0.9.10-incubating.md
@@ -7,8 +7,8 @@ summary: >
     Screen sharing, recording, improved file transfer, audio input, Docker
     support for LDAP.
 
-artifact-root: "http://apache.org/dyn/closer.cgi/"
-checksum-root: "http://www.apache.org/dist/"
+artifact-root: "http://apache.org/dyn/closer.cgi?action=download&filename="
+checksum-root: "https://www.apache.org/dist/"
 download-path: "incubator/guacamole/0.9.10-incubating/"
 
 source-dist:

--- a/_releases/0.9.10-incubating.md
+++ b/_releases/0.9.10-incubating.md
@@ -1,15 +1,15 @@
 ---
 
-released: false
+released: true
 title: 0.9.10-incubating
-date: 2016-12-18 12:23:00 -0800
+date: 2016-12-29 19:52:00 -0800
 summary: >
     Screen sharing, recording, improved file transfer, audio input, Docker
     support for LDAP.
 
-artifact-root: "https://dist.apache.org/repos/dist/dev/"
-checksum-root: "https://dist.apache.org/repos/dist/dev/"
-download-path: "incubator/guacamole/0.9.10-incubating-RC3/"
+artifact-root: "http://apache.org/dyn/closer.cgi/"
+checksum-root: "http://www.apache.org/dist/"
+download-path: "incubator/guacamole/0.9.10-incubating/"
 
 source-dist:
     - "source/guacamole-client-0.9.10-incubating.tar.gz"

--- a/releases.md
+++ b/releases.md
@@ -19,12 +19,32 @@ Which version should I download?
 
 Unless you already know that you need a *very* specific version (your custom or third-party extensions use an older version of the Guacamole API, for example), **you should always download the most recent release**. Guacamole development is very active, and recent releases will contain bug fixes and performance improvements that will be absent in older releases.
 
+<table class="releases">
+    <tr>
+        <th>Version</th>
+        <th>Summary</th>
+        <th>Release Date</th>
+    </tr>
+    {% assign releases = site.releases  | where: 'released', 'true' | sort: 'date' %}
+    {% for release in releases reversed %}
+        {% if release.title %}
+            <tr>
+                <td><a href="{{ release.url | prepend: site.baseurl }}">{{ release.title }}</a></td>
+                <td>{{ release.summary }}</td>
+                <td>{{ release.date | date: "%Y-%m-%d" }}</td>
+            </tr>
+        {% endif %}
+    {% endfor %}
+</table>
+
+Pre-Apache releases
+-------------------
+
 <div class="legacy-release-note">
-    <p>The Apache Guacamole project has not yet made a release through the
-    Apache Incubator. <strong>All releases below are from prior to Guacamole's
-    acceptance into the Incubator.</strong> They are not Apache Software
-    Foundation releases, and are licensed under the <a
-    href="https://opensource.org/licenses/MIT">MIT license</a>.</p>
+    <p><strong>All releases below are from prior to Guacamole's acceptance into
+    the Incubator.</strong> They are not Apache Software Foundation releases,
+    and are licensed under the <a
+        href="https://opensource.org/licenses/MIT">MIT license</a>.</p>
 </div>
 
 <table class="releases">


### PR DESCRIPTION
This change marks 0.9.10-incubating as released, and updates the release archives to separate legacy pre-Apache releases from releases made since acceptance into the Incubator.

We'll still need to hold off on actually *deploying* these changes until 2016-12-30 19:37 -0800, as that will be 24 hours since the release artifacts were deployed (and the mirrors need roughly 24 hours to sync). From http://www.apache.org/dev/release.html#release-announcements:

> Please ensure that you wait at least 24 hours after uploading a new release before updating the project download page and sending the announcement email(s). This is so that mirrors have sufficient time to catch up. (For time-critical security releases, the download pages script supports bypassing this requirement.)

Also, from http://www.apache.org/dev/release-publishing.html#sync-delay:

> Apache uses svnpubsub internally and rsync mirrroring externally. Files committed to the Subversion repository at https://dist.apache.org/repos/dist/ are automatically copied, using svnpubsub, to www.apache.org , and then the external mirrors pick up the files from www.apache.org. It may take up to 24 hours or more for a newly published release to be sync'd to all mirrors. Mirrors have their own schedules. [Mirrors are required](http://www.apache.org/info/how-to-mirror.html#Requirements) to check at least once a day, but most will check for updates 2 to 4 times per day.
