### PR TITLE
Link to latest release on index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,25 +2,35 @@
 layout: default
 ---
 
-<!-- Demo Video -->
-<div class="hook" markdown="1">
-<div class="demo">
-    <img class="thumbnail" src="/images/demo-thumbnail.jpg" alt="Screenshot of Guacamole 0.9.4"/>
-     <iframe
-        src="//player.vimeo.com/video/116207678?title=0&amp;byline=0&amp;portrait=0"
-        frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-</div>
-<div class="description" markdown="1">
-Apache Guacamole is a **clientless remote desktop gateway**. It supports
-standard protocols like VNC, RDP, and SSH.
+<!-- Prominent software description/demo -->
+<div class="hook">
 
-We call it _clientless_ because no plugins or client software are required.
+    <!-- Demo Video -->
+    <div class="demo">
+        <img class="thumbnail" src="/images/demo-thumbnail.jpg"
+             alt="Screenshot of Guacamole 0.9.4"/>
+         <iframe
+            src="//player.vimeo.com/video/116207678?title=0&amp;byline=0&amp;portrait=0"
+            frameborder="0" webkitallowfullscreen mozallowfullscreen
+            allowfullscreen></iframe>
+    </div>
 
-Thanks to HTML5, once Guacamole is installed on a server, all you need to
-access your desktops is a web browser.
-</div>
+    <!-- High-level description -->
+    <div class="description">
+        <p>Apache Guacamole is a <strong>clientless remote desktop
+        gateway</strong>. It supports standard protocols like VNC, RDP, and
+        SSH.</p>
+
+        <p>We call it <em>clientless</em> because no plugins or client software
+        are required.</p>
+
+        <p>Thanks to HTML5, once Guacamole is installed on a server, all you
+        need to access your desktops is a web browser.</p>
+    </div>
+
 </div>
 
+<!-- List of features -->
 <ul class="features">
     <li class="html5">
         <h2>Access your computers from <em>anywhere</em></h2>
@@ -43,6 +53,5 @@ access your desktops is a web browser.
         <h2>Commercially supported</h2>
         <p>For enterprises, dedicated commercial support is also available through <a href="/support/#commercial-support">third party companies</a>.</p>
     </li>
-</li>
 </ul>
 

--- a/index.html
+++ b/index.html
@@ -30,6 +30,13 @@ layout: default
 
 </div>
 
+<!-- Link to latest release -->
+<div class="latest-release">
+    {% assign latest = site.releases | where: 'released', 'true' | sort: 'date'  | last %}
+    Latest release: <a href="{{ latest.url }}"
+       class="version">{{ latest.title }}</a> (released on {{ latest.date }})
+</div>
+
 <!-- List of features -->
 <ul class="features">
     <li class="html5">

--- a/styles/main.css
+++ b/styles/main.css
@@ -22,7 +22,7 @@ a[href]:visited { color: #884; }
 
 div#header {
     color: white;
-    background: #304730;
+    background: #213121;
     display: table;
     width: 100%;
     padding: 1em;
@@ -119,7 +119,6 @@ ul.features li.commercially-supported::before {
 }
 
 .hook {
-    padding-bottom: 2em;
     overflow: hidden;
     background: #304730;
     color: white;
@@ -530,7 +529,6 @@ table.releases td {
     .hook {
         background: transparent;
         color: black;
-        padding-bottom: 0;
     }
 
     .hook .description {
@@ -611,17 +609,12 @@ table.releases td {
         text-align: center;
     }
 
-    .hook {
-        padding-bottom: 1em;
-    }
-
     .hook > * {
         margin: 0;
     }
 
     .demo {
-        margin-left: auto;
-        margin-right: auto;
+        margin: 1em auto;
     }
 
     .demo,

--- a/styles/main.css
+++ b/styles/main.css
@@ -141,7 +141,17 @@ ul.features li.commercially-supported::before {
     max-width: 40%;
 }
 
-.latest {
+.latest-release {
+    color: white;
+    background: #213121;
+    padding: 1em;
+    font-size: 0.8em;
+}
+
+.latest-release a[href].version,
+.latest-release a[href].version:visited {
+    color: white;
+    margin: 0.25em 0.5em;
     font-weight: bold;
 }
 
@@ -245,7 +255,8 @@ p {
     padding-right: 0.25in;
 }
 
-#content .hook {
+#content .hook,
+#content .latest-release {
     margin: 0;
     width: 100%;
 }


### PR DESCRIPTION
In further preparation for the release announcement a few hours from now, I've made some changes which add a link to the latest release to `index.html` while also cleaning the style somewhat:

![show-latest-release](https://cloud.githubusercontent.com/assets/4632905/21574393/ebd8b208-cea6-11e6-91f0-cf41c25fb147.png)

Note that this change also switches from Markdown to HTML for the index page, as it really may as well be HTML at this point.