### PR TITLE
Link to archive.apache.org for 0.9.11-incubating artifacts/checksums.

### DIFF
--- a/_releases/0.9.11-incubating.md
+++ b/_releases/0.9.11-incubating.md
@@ -7,8 +7,8 @@ summary: >
     Two-factor authentication, password policies, improvements to Docker and
     LDAP.
 
-artifact-root: "http://apache.org/dyn/closer.cgi?action=download&filename="
-checksum-root: "https://www.apache.org/dist/"
+artifact-root: "http://archive.apache.org/dist/"
+checksum-root: "https://archive.apache.org/dist/"
 download-path: "incubator/guacamole/0.9.11-incubating/"
 
 source-dist:


### PR DESCRIPTION
From Apache's [Release Distribution Policy](http://www.apache.org/dev/release-distribution#archival):

>
> ### RELEASES MUST BE ARCHIVED
>
> All releases MUST be archived on `archive.apache.org`. This generally happens via an automated process which adds releases to the archive about a day after they first appear on `www.apache.org/dist`.
>
> Each project's [distribution directory](http://www.apache.org/dev/release-distribution#dist-dir) SHOULD contain the latest release in each branch that is currently under development. When development ceases on a version branch, releases of that branch SHOULD be removed.
>

This change updates the links to 0.9.11-incubating to use archive.apache.org, such that the release can be safely removed from the dist area.