### PR TITLE
Release 0.9.13-incubating.

### DIFF
--- a/_releases/0.9.13-incubating.md
+++ b/_releases/0.9.13-incubating.md
@@ -1,15 +1,15 @@
 ---
 
-released: false
+released: true
 title: 0.9.13-incubating
-date: 2017-07-02 11:34:00 -0700
+date: 2017-07-30 22:06:00 -0700
 summary: >
     CAS single sign-on, fixes for VNC/RDP/SSH/telnet, in-browser playback of
     screen recordings, automatic connection failover, 256-color console codes.
 
-artifact-root: "https://dist.apache.org/repos/dist/dev/"
-checksum-root: "https://dist.apache.org/repos/dist/dev/"
-download-path: "incubator/guacamole/0.9.13-incubating-RC1/"
+artifact-root: "http://apache.org/dyn/closer.cgi?action=download&filename="
+checksum-root: "https://www.apache.org/dist/"
+download-path: "incubator/guacamole/0.9.13-incubating/"
 
 source-dist:
     - "source/guacamole-client-0.9.13-incubating.tar.gz"

--- a/doc/guacamole-common
+++ b/doc/guacamole-common
@@ -1,1 +1,1 @@
-0.9.10-incubating/guacamole-common
+0.9.13-incubating/guacamole-common

--- a/doc/guacamole-common-js
+++ b/doc/guacamole-common-js
@@ -1,1 +1,1 @@
-0.9.12-incubating/guacamole-common-js
+0.9.13-incubating/guacamole-common-js

--- a/doc/guacamole-ext
+++ b/doc/guacamole-ext
@@ -1,1 +1,1 @@
-0.9.12-incubating/guacamole-ext
+0.9.13-incubating/guacamole-ext

--- a/doc/gug
+++ b/doc/gug
@@ -1,1 +1,1 @@
-0.9.12-incubating/gug
+0.9.13-incubating/gug

--- a/doc/libguac
+++ b/doc/libguac
@@ -1,1 +1,1 @@
-0.9.12-incubating/libguac
+0.9.13-incubating/libguac


### PR DESCRIPTION
This change marks 0.9.13-incubating as released, and updates the top-level symbolic links to the latest documentation.

We'll still need to hold off on actually *deploying* these changes until 2017-08-01 00:01 -0700, as that will be 24 hours since the release artifacts were deployed (and the mirrors need roughly 24 hours to sync). From http://www.apache.org/dev/release.html#release-announcements:

> Please ensure that you wait at least 24 hours after uploading a new release before updating the project download page and sending the announcement email(s). This is so that mirrors have sufficient time to catch up. (For time-critical security releases, the download pages script supports bypassing this requirement.)

Also, from http://www.apache.org/dev/release-publishing.html#sync-delay:

> Apache uses svnpubsub internally and rsync mirrroring externally. Files committed to the Subversion repository at https://dist.apache.org/repos/dist/ are automatically copied, using svnpubsub, to www.apache.org , and then the external mirrors pick up the files from www.apache.org. It may take up to 24 hours or more for a newly published release to be sync'd to all mirrors. Mirrors have their own schedules. [Mirrors are required](http://www.apache.org/info/how-to-mirror.html#Requirements) to check at least once a day, but most will check for updates 2 to 4 times per day.
