### PR TITLE
Ubuntu Package Distinction

### DIFF
--- a/doc/0.9.13-incubating/gug/installing-guacamole.html
+++ b/doc/0.9.13-incubating/gug/installing-guacamole.html
@@ -36,7 +36,7 @@
                             </td></tr><tr><td><a class="link" href="http://libjpeg-turbo.virtualgl.org/" target="_top">libjpeg-turbo</a></td><td>
                                 <p>libjpeg-turbo is used by libguac to provide JPEG support.
                                     Guacamole will not build without this library present:</p>
-                                <div class="informaltable"><table border="0"><colgroup><col class="c1" /><col class="c2" /></colgroup><tbody><tr><th>Debian / Ubuntu package</th><td><span class="package">libjpeg62-turbo-dev</span></td></tr><tr><th>Fedora / CentOS / RHEL package</th><td><span class="package">libjpeg-turbo-devel</span></td></tr></tbody></table></div>
+                                <div class="informaltable"><table border="0"><colgroup><col class="c1" /><col class="c2" /></colgroup><tbody><tr><th>Debian package</th><td><span class="package">libjpeg62-turbo-dev</span></td></tr><tr><th>Ubuntu package</th><td><span class="package">libjpeg-turbo8-dev</span></td></tr><tr><th>Fedora / CentOS / RHEL package</th><td><span class="package">libjpeg-turbo-devel</span></td></tr></tbody></table></div>
                                 <p>If libjpeg-turbo is unavailable on your platform, and you do
                                     not wish to build it from source, <a class="link" href="http://www.ijg.org/" target="_top">libjpeg</a> will work as
                                     well, though it will not be quite as fast:</p>


### PR DESCRIPTION
On Ubuntu the libjpeg62-turbo-dev package is named libjpeg-turbo8-dev, the instructions don't make that clear, this may help.