### PR TITLE
Add cache-busting checksum to main.css link in head.

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,5 +1,7 @@
 <head>
-    <link rel="stylesheet" href="/styles/main.css">
+    <link rel="stylesheet" href="/styles/main.css?s={{
+        'styles/main.css' | checksum
+    }}">
     <link rel="icon" type="image/png" href="/images/guacamole-logo-64.png"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densitydpi=device-dpi"/>
     <meta charset="UTF-8"/>

--- a/_plugins/checksum.rb
+++ b/_plugins/checksum.rb
@@ -1,0 +1,27 @@
+require 'digest'
+
+module GuacChecksumFilter
+
+    #
+    # Returns an arbitrary, unique checksum for the given file, calculated from
+    # the file's contents. The resulting checksum is guaranteed to be safe for
+    # inclusion within URLs.
+    #
+    # == Parameters:
+    # input::
+    #     The name of the file to use to generate the checksum.
+    # 
+    # == Returns:
+    # An arbitrary, unique checksum generated from the contents of the given
+    # file.
+    #
+    def checksum(input)
+        digest = Digest::MD5.file input
+        digest.hexdigest
+    end
+
+end
+
+# Register checksum filter with Liquid
+Liquid::Template.register_filter(GuacChecksumFilter)
+


### PR DESCRIPTION
Recent changes from #46 revealed that the website CSS is cached much more thoroughly than the page contents, and returning users will tend to see new website content rendered with old styles. In the case of #46, this means the new dropdowns don't render correctly and the menu is absolutely full of links.

This change adds a Jekyll plugin which defines a Liquid filter for producing a unique checksum for a file (in this case using MD5). The `<link>` tag which points to the CSS has been modified to invoke this filter to append a query parameter which will change if and only if the CSS file contents change.