### PR TITLE
Correct YAML formatting of AFNSec (malformed frontmatter).

### DIFF
--- a/_companies/afnsec.md
+++ b/_companies/afnsec.md
@@ -1,3 +1,4 @@
+---
 title: AFNSec
 logo: /images/companies/afnsec.png
 location: https://afnsec.cm/sap


### PR DESCRIPTION
Did not notice at the time of reviewing #175 that the YAML frontmatter was malformed (missing initial `---`), which causes the listing to not render.

This change fixes that.